### PR TITLE
Removes use of deprecated (and removed) $wgParser

### DIFF
--- a/SemanticACL.class.php
+++ b/SemanticACL.class.php
@@ -464,10 +464,10 @@ class SemanticACL {
 	 * Disable caching for the page currently being rendered.
 	 */
 	protected static function disableCaching() {
-		global $wgParser;
+		$parser = MediaWikiServices::getInstance()->getParser();
 
-		if ( $wgParser->getOutput() ) {
-			$wgParser->getOutput()->updateCacheExpiry( 0 );
+		if ( $parser->getOutput() ) {
+			$parser->getOutput()->updateCacheExpiry( 0 );
 		}
 
 		RequestContext::getMain()->getOutput()->disableClientCache();


### PR DESCRIPTION
The global `$wgParser` was deprecated and completely removed in 1.39 [1]

1. https://www.mediawiki.org/wiki/Release_notes/1.39